### PR TITLE
fix: DOT-375 Add minimum length to git sha

### DIFF
--- a/scripts/helm.sh
+++ b/scripts/helm.sh
@@ -4,7 +4,7 @@ set -u
 
 function get_version() {
   local git_describe
-  git_describe=$(git describe --tag --match 'v*' 2>/dev/null | sed 's/^v//')
+  git_describe=$(git describe --abbrev=9 --tag --match 'v*' 2>/dev/null | sed 's/^v//')
 
   local suffix
   suffix=$(get_suffix)
@@ -22,12 +22,12 @@ function get_version() {
     #   v1.3.0-development.4-1-g76e8032 - tag is one commit behind HEAD
     echo "${git_describe}${suffix}"
   else
-    echo "${npm_package_version//-semantically-released/}-g$(git rev-parse --short HEAD)${suffix}"
+    echo "${npm_package_version//-semantically-released/}-g$(git rev-parse --short=9 HEAD)${suffix}"
   fi
 }
 
 function get_docker_tag() {
-  echo "$(git rev-parse --short HEAD)$(get_suffix)"
+  echo "$(git rev-parse --short=9 HEAD)$(get_suffix)"
 }
 
 function get_suffix() {


### PR DESCRIPTION
Explicitly tell GIT to return 9 digit SHAs